### PR TITLE
Removed usage reports option and code behind it

### DIFF
--- a/commons/res/xml/preferences.xml
+++ b/commons/res/xml/preferences.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference
-        android:key="eventLogging"
-        android:title="@string/preference_tracking"
-        android:summary="@string/preference_tracking_summary"
-        android:defaultValue="false"
-        />
+
     <ListPreference
         android:key="defaultLicense"
         android:title="@string/preference_license"

--- a/commons/src/main/java/org/wikimedia/commons/CommonsApplication.java
+++ b/commons/src/main/java/org/wikimedia/commons/CommonsApplication.java
@@ -65,7 +65,7 @@ public class CommonsApplication extends Application {
     public static final Object[] EVENT_LOGIN_ATTEMPT = {"MobileAppLoginAttempts", 5257721L};
     public static final Object[] EVENT_SHARE_ATTEMPT = {"MobileAppShareAttempts", 5346170L};
     public static final Object[] EVENT_CATEGORIZATION_ATTEMPT = {"MobileAppCategorizationAttempts", 5359208L};
-    public static final Object[] EVENT_EVENTLOGGING_CHANGE = {"MobileAppTrackingChange", 5369400L};
+    
 
     public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using Android Commons app";
 

--- a/commons/src/main/java/org/wikimedia/commons/SettingsActivity.java
+++ b/commons/src/main/java/org/wikimedia/commons/SettingsActivity.java
@@ -54,13 +54,6 @@ public class SettingsActivity extends SherlockPreferenceActivity implements Shar
     }
 
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if(key.equals(Prefs.TRACKING_ENABLED)) {
-            // We force log this, so it is logged even if EL is turned off
-            EventLog.schema(CommonsApplication.EVENT_EVENTLOGGING_CHANGE)
-                    .param("username", app.getCurrentAccount().name)
-                    .param("state", sharedPreferences.getBoolean(key, true))
-                    .log(true);
-        }
 
     }
 }


### PR DESCRIPTION
Fixes issue #11 . Removed the option in Settings layout file as well as the condition that checks for that option being enabled (in SettingsActivity) and the static Object in CommonsApplication that stores it.