### PR TITLE
enable minify for release

### DIFF
--- a/commons/app/build.gradle
+++ b/commons/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/commons/app/proguard-rules.txt
+++ b/commons/app/proguard-rules.txt
@@ -1,3 +1,3 @@
 -dontobfuscate
--ignorewarnings
-
+-keep class org.apache.http.** { *; }
+-dontwarn org.apache.http.**

--- a/commons/app/proguard-rules.txt
+++ b/commons/app/proguard-rules.txt
@@ -1,0 +1,3 @@
+-dontobfuscate
+-ignorewarnings
+


### PR DESCRIPTION
It appears that it can reduce the APK size by 600KB, which is not bad.

> 
> 2828	build/outputs/apk/app-debug-unaligned.apk
> 2828	build/outputs/apk/app-debug.apk
> 2240	build/outputs/apk/app-release-unaligned.apk
> 2204	build/outputs/apk/app-release-unsigned.apk
> 

`-ignorewarnings` is a workaround that should be replaced with a proper fix later, but it already appears to work. I just run the app and there was no apparent breakage by the minification. (I haven't tested every feature of the app, though.)

