### PR TITLE
Make AuthenticatedActivity abstract (per lint)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
@@ -11,7 +11,7 @@ import android.support.v7.app.AppCompatActivity;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.Utils;
 
-public class AuthenticatedActivity extends AppCompatActivity {
+public abstract class AuthenticatedActivity extends AppCompatActivity {
     
     
     String accountType;
@@ -143,10 +143,6 @@ public class AuthenticatedActivity extends AppCompatActivity {
         outState.putString("authCookie", authCookie);
     }
 
-    protected void onAuthCookieAcquired(String authCookie) {
-        
-    }
-    protected void onAuthFailure() {
-        
-    }
+    protected abstract void onAuthCookieAcquired(String authCookie);
+    protected abstract void onAuthFailure();
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -188,7 +188,6 @@ public  class       ContributionsActivity
 
     @Override
     protected void onAuthFailure() {
-        super.onAuthFailure();
         finish(); // If authentication failed, we just exit
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -236,7 +236,6 @@ public  class       MultipleShareActivity
 
     @Override
     protected void onAuthFailure() {
-        super.onAuthFailure();
         Toast failureToast = Toast.makeText(this, R.string.authentication_failed, Toast.LENGTH_LONG);
         failureToast.show();
         finish();

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -158,7 +158,6 @@ public  class       ShareActivity
 
     @Override
     protected void onAuthCookieAcquired(String authCookie) {
-        super.onAuthCookieAcquired(authCookie);
         app.getApi().setAuthCookie(authCookie);
 
 
@@ -176,7 +175,6 @@ public  class       ShareActivity
 
     @Override
     protected void onAuthFailure() {
-        super.onAuthFailure();
         Toast failureToast = Toast.makeText(this, R.string.authentication_failed, Toast.LENGTH_LONG);
         failureToast.show();
         finish();


### PR DESCRIPTION
This is to fix an issue (among many) reported by `gradle lint`.