### PR TITLE
Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: android
+android:
+  components:
+    - platform-tools
+    - tools
+    - build-tools-23.0.3
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - android-23
+    - sys-img-x86-android-18

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,5 +44,6 @@ android {
     lintOptions {
         disable 'MissingTranslation'
         disable 'ExtraTranslation'
+        abortOnError false
     }
 }


### PR DESCRIPTION
This is something minimal to start continuous integration. It should catch compile errors and other errors that make the package not buildable.

Lint errors are ignored for now (`abortOnError false`). As soon as we are in a good shape with Issue  #171, we can turn it on.