### PR TITLE
Migrate event logging to www.wikimedia.org/beacon

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -52,7 +52,7 @@ public class CommonsApplication extends Application {
     public static final String API_URL = "https://commons.wikimedia.org/w/api.php";
     public static final String IMAGE_URL_BASE = "https://upload.wikimedia.org/wikipedia/commons";
     public static final String HOME_URL = "https://commons.wikimedia.org/wiki/";
-    public static final String EVENTLOG_URL = "https://bits.wikimedia.org/event.gif";
+    public static final String EVENTLOG_URL = "https://www.wikimedia.org/beacon/event";
     public static final String EVENTLOG_WIKI = "commonswiki";
 
     public static final Object[] EVENT_UPLOAD_ATTEMPT = {"MobileAppUploadAttempts", 5334329L};

--- a/upload-to-commons.patch
+++ b/upload-to-commons.patch
@@ -13,7 +13,7 @@ index 3fe594d..8306000 100644
 +    public static final String IMAGE_URL_BASE = "https://upload.wikimedia.org/wikipedia/commons";
 +    public static final String HOME_URL = "https://commons.wikimedia.org/wiki/";
 +
-     public static final String EVENTLOG_URL = "https://bits.wikimedia.org/event.gif";
+     public static final String EVENTLOG_URL = "https://www.wikimedia.org/beacon/event";
 -    public static final String EVENTLOG_WIKI = "testwiki";
 +    public static final String EVENTLOG_WIKI = "commonswiki";
  


### PR DESCRIPTION
Fixes #220.